### PR TITLE
Switch to requirements-based spec for inclusion phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The protocol operates in rounds, which are not the same as priority epochs. Ther
 
 Each round operates in three phases, and results in pushing a sequence of transactions into a queue which will be consumed by the block-building engine.
 
-- The *inclusion* phase produces a consensus inclusion list, which is an unordered set of transactions and priority bundles. Each transaction (or bundle) in an inclusion list may or may not be encrypted under the threshold encryption scheme.
+- The *inclusion* phase produces a consensus inclusion list, which contains a set of transactions and priority bundles, and some metadata. Each transaction (or bundle) in an inclusion list may or may not be encrypted under the threshold encryption scheme.
 - The *decryption* phase takes the consensus inclusion list produced by the inclusion phase, and threshold-decrypts any encrypted transactions or bundles in the list.
 - The *ordering* phase takes the decrypted inclusion list produced by the decryption phase, and produces an ordered sequence of timestamped transactions, which are pushed into a queue that will be consumed by the block-building engine. 
 
@@ -98,6 +98,55 @@ The inclusion phase operates on its own cadence, starting the next consensus rou
 **Inclusion phase**
 
 The inclusion phase uses the consensus sub-protocol, making a best effort to start the rounds of the consensus sub-protocol at 250 millisecond intervals. 
+
+The inclusion phase is specified as a set of properties that the inclusion sub-protocol must satisfy.  This is followed by a description of a reference implementation strategy, which satisfies those properties.  The reference is included for its explanatory value; implementations can use a different strategy as long as the required properties are satisfied.
+
+**Inclusion phase: required properties**
+
+Assumptions:
+
+- Each member has a local clock, which is non-decreasing. These satisfy:
+  - liveness: if one honest member’s clock is $t$, then all honest members’ clocks will eventually be $\ge t$.
+  - bounded skew: If $m$ and $m'$ are honest members, then $|m.\mathrm{clock}-m'.\mathrm{clock}| \le d$ for some known bound $d$
+- The L1 delayed inbox (a contract on the L1 chain) has a finality number, which is non-decreasing.
+- Each member has a view of the delayed inbox finality number, which satisfies:
+  - safety: the member’s view is $\le$ the true number
+  - liveness: if the true number is $i$, then the member’s view will eventually be $\le i$
+
+The result of a round is either FAILURE or a block that contains:
+
+- a round number $R > 0$
+- a predecessor round number $P$
+- a consensus timestamp $T_R$
+- a pair of delayed inbox finality numbers, $I_{R,\mathrm{first}}$ and $I_{R,\mathrm{next}}$
+- an unordered set $N_R$ of (possibly encrypted) non-priority transactions
+- an ordered set $B_R$ of (possibly encrypted) priority bundles
+
+Standard consensus properties:
+
+- If an honest member has committed a result for round $R > 0$, then it has committed a result for round $R-1$.
+- If two honest members both commit a result for round $R$, then they commit the same result.
+- If some honest member commits a result for round $R$, then all honest members will eventually commit a result for round $R$.
+
+If a non-FAILURE result has been committed by an honest member for a round $R > 0$, then at the time of commitment and all later times, the result satisfies these properties:
+
+- $P < R$
+- for all $i$ such that $P < i < R$: the member committed FAILURE as the result of round $i$
+- $T_R \ge T_P$
+- there is some honest member $m$ such that $T_R \le$  $m.\mathrm{clock}$
+- for all $n \in N_R$, there is some honest member $m$ such that $n$ arrived at $m$ before time $T_R+d-250\ \mathrm{milliseconds}$, according to $m$’s local clock
+- $I_\mathrm{R,\mathrm{first}} = I_{P,\mathrm{next}}$
+- $I_{R,\mathrm{first}} \le I_{R,\mathrm{next}} \le I$ where $I$ is the true L1 delayed inbox finality number
+- the bundles in $B_R$ are sorted in increasing order of sequence number
+- If a bundle $b \in B_R$ and $b$ has epoch $e_b$ and sequence number $s_b$, then:
+  - $e_b = \mathrm{epoch}(T_R)$
+  - for every bundle $b' \in B_P$, either $e_{b'} < e_b$ or ($e_{b'} = e_b$ and $s_{b'} < s_b$)
+  - if $s_b \ne 0$, then there is some $R' \le R$ and  $b' \in B_{R'}$ such that $e_{b'} = e_b$ and $s_{b'} = s_b-1$
+- If a non-priority transaction has arrived at all honest members, it will eventually be in the result of some round.
+- Let $n$ be a non-priority transaction that is included in the result of round $R$, and $b$ be a priority bundle that is included in the result of round $R' > R$. Let $b$ have epoch number $e_b$ and sequence number $s_b$. Let $\tau$ be the (universal) time at when $n$ first arrived at any member. Then there is some $s \le s_b$ such that bundles with epoch $e_b$ and sequence number $s$ arrived at fewer than $F+1$ members before $\tau+250\ \mathrm{milliseconds}$.
+- [open question: Can we write an inclusion guarantee for priority bundles? This is difficult because of the constraints on when/how they can be included. As an example, a bundle is tied to a priority epoch, so it can only be included within a fixed range of consensus timestamps corresponding to that epoch; but if the network is asynchronous then we can’t even guarantee that any round will start or finish during that epoch.]
+
+**Inclusion phase: reference implementation strategy**
 
 In each round of the consensus sub-protocol, each committee member submits a candidate list of transactions. The consensus round’s result is a list of *N-F* of the candidate lists submitted for that round (or no result, if the consensus round fails).
 
@@ -170,70 +219,47 @@ Such a member should record the results of consensus rounds. To get its state in
 
 After doing these things, the member will be in sync and can start participating actively in future rounds of the protocol, including computing the consensus inclusion list and passing on new information to later rounds of the protocol.
 
-**Guaranteed properties of the inclusion phase:**
+**Decryption phase**
 
-- If *F+1* honest members receive a priority bundle before starting a round, and the round does not fail, that priority bundle will be in the inclusion list produced by the round (if not in an earlier round).
+Some or all of the transactions and bundles in the consensus inclusion list may be encrypted. The decryption phase will decrypt them. This phase consumes the results of the inclusion phase, which will be the same for all honest members, and all honest members will produce the same output for this phase.
 
-- If all honest members receive a non-priority transaction at least 250 milliseconds before a round starts, and the round does not fail, that transaction will be in the inclusion list produced by the round (if not in an earlier round).
+The decryption phases of multiple rounds can be done concurrently.
 
-- A transaction received by *F+1* honest members will eventually be included in the inclusion list produced by some round. (Such a transaction will eventually be in one of the candidate lists produced by a round of the consensus protocol, and thereafter all honest members will have received the transaction.)
+If any of the transactions or bundles in the inclusion list are encrypted, the committee member multicasts its decryption shares for the encrypted items. It then awaits the arrival of decryption shares from other committee members. As soon as it has received *F+1* decryption shares for an encrypted item (including its own share), it can use those shares to decrypt the item.
 
-- If priority bundle B (and also all priority bundles from the same epoch that have lower sequence numbers) is received by *F+1* honest members by time *tb*, and non-priority transaction T is first received by an honest member at time *tt*, and *tb* < *tt*+250 milliseconds, and if B is in the inclusion list of round R, then T will not be in the inclusion list of any round earlier than R.
+(Note that decryption of a non-priority transaction could lead to duplicate copies of the same transaction, because the result of decryption could be identical to a transaction that is already present. This cannot happen for priority bundles, nor for delayed inbox messages, because they have sequence numbers that have already been de-duplicated.)
 
-- If two priority bundles from the same epoch have sequence numbers *i* and *j>i*, and *j* is included in a consensus inclusion list, then either *i* is included in an earlier consensus inclusion list, or *i* is included in the same consensus inclusion list in an earlier position.
+As soon as the member has decrypted all of the encrypted items in the inclusion list (or immediately, if there were no encrypted items), it first de-duplicates the set of non-priority transactions by removing all but one instance of any transaction that is duplicated in the set, and then the member passes the de-duplicated inclusion list, tagged with the round number, to the next, ordering phase. 
 
-- The consensus timestamp is both:
+<u>State and recovery in the decryption phase</u>
 
-  - Less than or equal to the timestamp submitted to the current round by some honest party, and
-  - Greater than or equal to the timestamp submitted to the current round or some previous round by some honest party
+The decryption phase is stateless. No state needs to be remembered from one round to the next. So a member can participate in the decryption phase of any round, if it knows the correct inclusion list result for that round.
 
-- The consensus delayed inbox index is all of these:
+**Ordering phase**
 
-  - Less than or equal to the largest index of any delayed inbox message that has achieved finality on the parent chain, and
-  - Less than or equal to the delayed inbox index submitted to the current round by some honest party, and
-  - Greater than or equal to the delayed inbox index submitted to the current round or some previous round by some honest party 
+Each honest committee member runs a separate instance of the ordering phase. This phase is deterministic, and consumes inputs that will be the same for all honest members, so it will produce the same sequence of outputs for every honest member.
 
-  **Decryption phase**
+The ordering phase consumes the inclusion lists produced by the decryption phase, and produces an ordered sequence of timestamped transactions, which are pushed into a queue that will be consumed by the block building engine. 
 
-  Some or all of the transactions and bundles in the consensus inclusion list may be encrypted. The decryption phase will decrypt them. This phase consumes the results of the inclusion phase, which will be the same for all honest members, and all honest members will produce the same output for this phase.
+The inclusion lists from multiple rounds can be processed concurrently, however the results must be emitted from the ordering phase in round order.
 
-  The decryption phases of multiple rounds can be done concurrently.
+An honest member sorts the transactions and bundles in the inclusion list as follows:
 
-  If any of the transactions or bundles in the inclusion list are encrypted, the committee member multicasts its decryption shares for the encrypted items. It then awaits the arrival of decryption shares from other committee members. As soon as it has received *F+1* decryption shares for an encrypted item (including its own share), it can use those shares to decrypt the item.
+- order all priority transactions or bundles ahead of all non-priority transactions
+- among the priority transactions or bundles, order according to the sequence number given by the priority controller, then break up each bundle into its constituent transactions (by SSZ-decoding the payload as a List[List, 1048576], 1024]), maintaining the order from the bundle
+- among the non-priority transactions, order according to Hash(seed || sender address), breaking remaining ties by nonce (increasing), breaking remaining ties by Hash(contents)
+- among the delayed-inbox transactions, order by arrival order in the L1 inbox
 
-  (Note that decryption of a non-priority transaction could lead to duplicate copies of the same transaction, because the result of decryption could be identical to a transaction that is already present. This cannot happen for priority bundles, nor for delayed inbox messages, because they have sequence numbers that have already been de-duplicated.)
+At this point, the ordering phase waits until the ordering phases of all previous rounds have completed, and then:
 
-  As soon as the member has decrypted all of the encrypted items in the inclusion list (or immediately, if there were no encrypted items), it first de-duplicates the set of non-priority transactions by removing all but one instance of any transaction that is duplicated in the set, and then the member passes the de-duplicated inclusion list, tagged with the round number, to the next, ordering phase. 
+- Pushes the transactions in order, and timestamped with the consensus timestamp from their inclusion list, into the input queue of the block building engine.
+- Push the indices in the consensus delayed inbox index sequence,  in increasing order, into the input queue of the block building engine. (Note that the interval might be empty.)
 
-  <u>State and recovery in the decryption phase</u>
+This completes the ordering phase for the round.
 
-  The decryption phase is stateless. No state needs to be remembered from one round to the next. So a member can participate in the decryption phase of any round, if it knows the correct inclusion list result for that round.
+<u>State and recovery for the ordering phase</u>
 
-  **Ordering phase**
-
-  Each honest committee member runs a separate instance of the ordering phase. This phase is deterministic, and consumes inputs that will be the same for all honest members, so it will produce the same sequence of outputs for every honest member.
-
-  The ordering phase consumes the inclusion lists produced by the decryption phase, and produces an ordered sequence of timestamped transactions, which are pushed into a queue that will be consumed by the block building engine. 
-
-  The inclusion lists from multiple rounds can be processed concurrently, however the results must be emitted from the ordering phase in round order.
-
-  An honest member sorts the transactions and bundles in the inclusion list as follows:
-
-  - order all priority transactions or bundles ahead of all non-priority transactions
-  - among the priority transactions or bundles, order according to the sequence number given by the priority controller, then break up each bundle into its constituent transactions (by SSZ-decoding the payload as a List[List, 1048576], 1024]), maintaining the order from the bundle
-  - among the non-priority transactions, order according to Hash(seed || sender address), breaking remaining ties by nonce (increasing), breaking remaining ties by Hash(contents)
-  - among the delayed-inbox transactions, order by arrival order in the L1 inbox
-
-  At this point, the ordering phase waits until the ordering phases of all previous rounds have completed, and then:
-
-  - Pushes the transactions in order, and timestamped with the consensus timestamp from their inclusion list, into the input queue of the block building engine.
-  - Push the indices in the consensus delayed inbox index sequence,  in increasing order, into the input queue of the block building engine. (Note that the interval might be empty.)
-
-  This completes the ordering phase for the round.
-
-  <u>State and recovery for the ordering phase</u>
-
-  Each round of the ordering phase is self-contained, and there is no state that needs to be remembered from one round to the next. So a member can execute the ordering phase for any round for which it knows the correct result of the decryption phase.
+Each round of the ordering phase is self-contained, and there is no state that needs to be remembered from one round to the next. So a member can execute the ordering phase for any round for which it knows the correct result of the decryption phase.
 
 **Block building engine**
 


### PR DESCRIPTION
Specify the inclusion phase via a set of requirements, and change the previous protocol spec into a reference implementation strategy rather than a requirement.

This should give implementers more latitude to choose their core consensus strategy.